### PR TITLE
add optional on_stop parameter to start_link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: elixir
 matrix:
   include:
-    - name: "Elixir 1.6 / OTP 20"
-      elixir: 1.6
-      otp_release: 20.0
     - name: "Elixir 1.7 / OTP 20"
       elixir: 1.7
       otp_release: 20.0

--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -2,9 +2,9 @@ defmodule Singleton do
   @moduledoc """
   Singleton application.
 
-  The top supervisor of singleton is a `:simple_one_for_one`
-  supervisor. Singleton can manage many singleton processes at the
-  same time. Each singleton is identified by its unique `name` term.
+  The top supervisor of singleton is a DynamicSupervisor. Singleton
+  can manage many singleton processes at the same time. Each singleton
+  is identified by its unique `name` term.
 
   """
 
@@ -20,7 +20,9 @@ defmodule Singleton do
   end
 
   @doc """
-  Start a new singleton process.
+  Start a new singleton process. Optionally provide the `on_stop`
+  parameter which will be called whenever a singleton process shuts
+  down due to another instance being present in the cluster.
 
   This function needs to be executed on all nodes where the singleton
   process is allowed to live. The actual process will be started only
@@ -29,12 +31,18 @@ defmodule Singleton do
   case of node disconnects or crashes.
 
   """
-  def start_child(module, args, name) do
+  def start_child(module, args, name, on_stop \\ fn -> nil end) do
     child_name = name(module, args)
 
     spec =
       {Singleton.Manager,
-       [mod: module, args: args, name: name, child_name: child_name]}
+       [
+         mod: module,
+         args: args,
+         name: name,
+         child_name: child_name,
+         on_stop: on_stop
+       ]}
 
     DynamicSupervisor.start_child(Singleton.Supervisor, spec)
   end

--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -20,7 +20,7 @@ defmodule Singleton do
   end
 
   @doc """
-  Start a new singleton process. Optionally provide the `on_stop`
+  Start a new singleton process. Optionally provide the `on_conflict`
   parameter which will be called whenever a singleton process shuts
   down due to another instance being present in the cluster.
 
@@ -31,7 +31,7 @@ defmodule Singleton do
   case of node disconnects or crashes.
 
   """
-  def start_child(module, args, name, on_stop \\ fn -> nil end) do
+  def start_child(module, args, name, on_conflict \\ fn -> nil end) do
     child_name = name(module, args)
 
     spec =
@@ -41,7 +41,7 @@ defmodule Singleton do
          args: args,
          name: name,
          child_name: child_name,
-         on_stop: on_stop
+         on_conflict: on_conflict
        ]}
 
     DynamicSupervisor.start_child(Singleton.Supervisor, spec)

--- a/lib/singleton/manager.ex
+++ b/lib/singleton/manager.ex
@@ -22,18 +22,26 @@ defmodule Singleton.Manager do
   @doc """
   Start the manager process, registering it under a unique name.
   """
-  def start_link(mod: mod, args: args, name: name, child_name: child_name) do
-    GenServer.start_link(__MODULE__, [mod, args, name], name: child_name)
+  def start_link(
+        mod: mod,
+        args: args,
+        name: name,
+        child_name: child_name,
+        on_stop: on_stop
+      ) do
+    GenServer.start_link(__MODULE__, [mod, args, name, on_stop],
+      name: child_name
+    )
   end
 
   defmodule State do
     @moduledoc false
-    defstruct pid: nil, mod: nil, args: nil, name: nil
+    defstruct pid: nil, mod: nil, args: nil, name: nil, on_stop: nil
   end
 
   @doc false
-  def init([mod, args, name]) do
-    state = %State{mod: mod, args: args, name: name}
+  def init([mod, args, name, on_stop]) do
+    state = %State{mod: mod, args: args, name: name, on_stop: on_stop}
     {:ok, restart(state)}
   end
 
@@ -55,8 +63,12 @@ defmodule Singleton.Manager do
 
     pid =
       case start_result do
-        {:ok, pid} -> pid
-        {:error, {:already_started, pid}} -> pid
+        {:ok, pid} ->
+          pid
+
+        {:error, {:already_started, pid}} ->
+          state.on_stop.()
+          pid
       end
 
     Process.monitor(pid)

--- a/lib/singleton/manager.ex
+++ b/lib/singleton/manager.ex
@@ -27,21 +27,21 @@ defmodule Singleton.Manager do
         args: args,
         name: name,
         child_name: child_name,
-        on_stop: on_stop
+        on_conflict: on_conflict
       ) do
-    GenServer.start_link(__MODULE__, [mod, args, name, on_stop],
+    GenServer.start_link(__MODULE__, [mod, args, name, on_conflict],
       name: child_name
     )
   end
 
   defmodule State do
     @moduledoc false
-    defstruct pid: nil, mod: nil, args: nil, name: nil, on_stop: nil
+    defstruct pid: nil, mod: nil, args: nil, name: nil, on_conflict: nil
   end
 
   @doc false
-  def init([mod, args, name, on_stop]) do
-    state = %State{mod: mod, args: args, name: name, on_stop: on_stop}
+  def init([mod, args, name, on_conflict]) do
+    state = %State{mod: mod, args: args, name: name, on_conflict: on_conflict}
     {:ok, restart(state)}
   end
 
@@ -67,7 +67,7 @@ defmodule Singleton.Manager do
           pid
 
         {:error, {:already_started, pid}} ->
-          state.on_stop.()
+          state.on_conflict.()
           pid
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Singleton.Mixfile do
     [
       app: :singleton,
       version: File.read!("VERSION"),
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This is really useful if your singleton process has some additional processes which it spins up during its execution.
My use-case is that I have a singleton process which schedules workers via Quantum. When my singleton shuts down, those quantum workers are still being scheduled. The on_stop function allows me to turn off my Quantum scheduler too.