### PR TITLE
Let user run Singleton under their application's supervision tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If your application includes a supervision tree in `application.ex`, you can sim
 ```elixir
 children = [
   # ...,
-  Singleton.Supervisor
+  {Singleton.Supervisor, name: MyApp.Sinlgeton}
 ]
 
 supervisor = Supervisor.start_link(children, opts)
@@ -35,7 +35,7 @@ supervisor = Supervisor.start_link(children, opts)
 
 Use `Singleton.start_child/3` to start a unique GenServer process.
 ```elixir
-Singleton.start_child(MyServer, [1], {:myserver, 1})
+Singleton.start_child(MyApp.Sinlgeton, MyServer, [1], {:myserver, 1})
 ```
 
 Execute this command on all nodes. The `MyServer` GenServer is now

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If your application includes a supervision tree in `application.ex`, you can sim
 ```elixir
 children = [
   # ...,
-  {Singleton.Supervisor, name: MyApp.Sinlgeton}
+  {Singleton.Supervisor, name: MyApp.Singleton}
 ]
 
 supervisor = Supervisor.start_link(children, opts)
@@ -35,7 +35,7 @@ supervisor = Supervisor.start_link(children, opts)
 
 Use `Singleton.start_child/3` to start a unique GenServer process.
 ```elixir
-Singleton.start_child(MyApp.Sinlgeton, MyServer, [1], {:myserver, 1})
+Singleton.start_child(MyApp.Singleton, MyServer, [1], {:myserver, 1})
 ```
 
 Execute this command on all nodes. The `MyServer` GenServer is now

--- a/README.md
+++ b/README.md
@@ -13,25 +13,30 @@ The package can be installed as:
 
   1. Add `singleton` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:singleton, "~> 1.0.0"}]
-    end
-    ```
+```elixir
+def deps do
+  [{:singleton, "~> 1.0.0"}]
+end
+```
 
-  2. Ensure `singleton` is started before your application:
+  2. Ensure `Singleton.Supervisor` is added to your application's supervision tree:
 
-    ```elixir
-    def application do
-      [applications: [:singleton]]
-    end
-    ```
+If your application includes a supervision tree in `application.ex`, you can simply add `Singleton.Supervisor` to the list of children.
+```elixir
+children = [
+  # ...,
+  Singleton.Supervisor
+]
+
+supervisor = Supervisor.start_link(children, opts)
+```
 
 ## Usage
 
 Use `Singleton.start_child/3` to start a unique GenServer process.
-
-    Singleton.start_child(MyServer, [1], {:myserver, 1})
+```elixir
+Singleton.start_child(MyServer, [1], {:myserver, 1})
+```
 
 Execute this command on all nodes. The `MyServer` GenServer is now
 globally registered under the name `{:global, {:myserver, 1}}`.

--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -19,7 +19,13 @@ defmodule Singleton do
   case of node disconnects or crashes.
 
   """
-  def start_child(supervisor_name, module, args, name, on_conflict \\ fn -> nil end) do
+  def start_child(
+        supervisor_name,
+        module,
+        args,
+        name,
+        on_conflict \\ fn -> nil end
+      ) do
     child_name = name(module, args)
 
     spec =

--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -50,7 +50,7 @@ defmodule Singleton do
 
             children = [
               ...,
-              {Singleton.Supervisor, name: MyApp.Sinlgeton}
+              {Singleton.Supervisor, name: MyApp.Singleton}
             ]
 
             supervisor = Supervisor.start_link(children, opts)

--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -27,8 +27,8 @@ defmodule Singleton do
        [
          mod: module,
          args: args,
-         name: child_name,
-         child_name: name,
+         name: name,
+         child_name: child_name,
          on_conflict: on_conflict
        ]}
 

--- a/lib/singleton/manager.ex
+++ b/lib/singleton/manager.ex
@@ -29,8 +29,8 @@ defmodule Singleton.Manager do
         child_name: child_name,
         on_conflict: on_conflict
       ) do
-    GenServer.start_link(__MODULE__, [mod, args, name, on_conflict],
-      name: child_name
+    GenServer.start_link(__MODULE__, [mod, args, child_name, on_conflict],
+      name: name
     )
   end
 

--- a/lib/singleton/manager.ex
+++ b/lib/singleton/manager.ex
@@ -29,8 +29,8 @@ defmodule Singleton.Manager do
         child_name: child_name,
         on_conflict: on_conflict
       ) do
-    GenServer.start_link(__MODULE__, [mod, args, child_name, on_conflict],
-      name: name
+    GenServer.start_link(__MODULE__, [mod, args, name, on_conflict],
+      name: child_name
     )
   end
 

--- a/lib/singleton/supervisor.ex
+++ b/lib/singleton/supervisor.ex
@@ -7,8 +7,8 @@ defmodule Singleton.Supervisor do
 
   require Logger
 
-  def start_link(init_arg) do
-    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  def start_link(name: name) do
+    DynamicSupervisor.start_link(__MODULE__, [], name: name)
   end
 
   @impl true

--- a/lib/singleton/supervisor.ex
+++ b/lib/singleton/supervisor.ex
@@ -1,0 +1,18 @@
+defmodule Singleton.Supervisor do
+  @moduledoc """
+  Singleton supervisor.
+  """
+
+  use DynamicSupervisor
+
+  require Logger
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Singleton.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger], mod: {Singleton, {}}]
+    [applications: [:logger]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/singleton_test.exs
+++ b/test/singleton_test.exs
@@ -1,6 +1,11 @@
 defmodule SingletonTest do
   use ExUnit.Case
 
+  setup do
+    {:ok, pid} = Singleton.Supervisor.start_link([])
+    {:ok, pid: pid}
+  end
+
   # doctest Singleton
 
   defmodule Foo do

--- a/test/support/singleton_dist.ex
+++ b/test/support/singleton_dist.ex
@@ -10,7 +10,7 @@ defmodule Singleton.Dist do
   end
 
   def setup do
-    Application.start(:singleton)
-    Singleton.start_child(TestServer, [], TestServer)
+    {:ok, _pid} = Singleton.Supervisor.start_link(name: Singleton.Supervisor)
+    Singleton.start_child(Singleton.Supervisor, TestServer, [], TestServer)
   end
 end


### PR DESCRIPTION
Is there a reason why a user would want this running as its own OTP application? Also, running it as a separate application was always breaking my application as described in README was always breaking my app, but I think elixir runs the apps listed in deps() as applications now anyways.

This merge would require an increased major version, then I guess the README should be updated as well w/ new version.