### PR TITLE
fix: allow to run more than 3 singletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ like:
 
 When you now stop (or disconnect) the node on which the singleton
 process runs, you'll see it get started on one of the other nodes.
+
+## Troubleshooting
+
+### More than 3 singleton processes `[info]  Application singleton exited: shutdown`
+
+In case you run more than 3 singleton you'll need to increase the
+`max_restarts` of `DynamicSupervisor`.
+
+```elixir
+config :singleton,
+  dynamic_supervisor: [max_restarts: 100]
+```

--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -13,10 +13,7 @@ defmodule Singleton do
   require Logger
 
   def start(_, _) do
-    DynamicSupervisor.start_link(
-      strategy: :one_for_one,
-      name: Singleton.Supervisor
-    )
+    DynamicSupervisor.start_link(dynamic_supervisor_options())
   end
 
   @doc """
@@ -59,5 +56,13 @@ defmodule Singleton do
   defp name(module, args) do
     bin = :crypto.hash(:sha, :erlang.term_to_binary({module, args}))
     String.to_atom("singleton_" <> Base.encode64(bin, padding: false))
+  end
+
+  defp dynamic_supervisor_options() do
+    [
+      strategy: :one_for_one,
+      name: Singleton.Supervisor
+    ]
+    |> Keyword.merge(Application.get_env(:singleton, :dynamic_supervisor, []))
   end
 end


### PR DESCRIPTION
It seems that you cannot run more than 3 singletons at the same time.
This limitations came from the `max_restarts` option of `DynamicSupervisor`.

Demo to reproduce the issue: https://github.com/klacointe/singleton_demo