### PR TITLE
change: Fix all application warnings.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Singleton.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger], mod: {Singleton, {}}]
+    [applications: [:logger, :crypto], mod: {Singleton, {}}]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
@@ -42,7 +42,7 @@ defmodule Singleton.Mixfile do
 
   defp deps do
     [
-      {:dialyxir, "~> 0.5", only: [:test, :dev], runtime: false}
+      {:dialyxir, "~> 1.2", only: [:test, :dev], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
 }


### PR DESCRIPTION
It includes:
 - import Config over use Mix.Config
 - missing :crypto lib over extra_applications
 - Update dialyzer version

Congratulations for the library, it is being extremely useful in my project!

We found this warning below when using it and I took the opportunity to make the correction available because it is something simple.

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/91558705/214072208-3729bc7f-d93e-4323-91fa-fb5d56887fd6.png">


If you can generate a tag with the same thank you very much!